### PR TITLE
Remove console.log when outputToFile set

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,9 +144,6 @@ module.exports = class SpeedMeasurePlugin {
           ? fs.appendFileSync
           : fs.writeFileSync;
         writeMethod(this.options.outputTarget, output + "\n");
-        console.log(
-          smpTag() + "Outputted timing info to " + this.options.outputTarget
-        );
       } else {
         const outputFunc = this.options.outputTarget || console.log;
         outputFunc(output);


### PR DESCRIPTION
This pr just removes a console.log and fixes [Issue 157](https://github.com/stephencookdev/speed-measure-webpack-plugin/issues/157) 